### PR TITLE
Remove OCSInitialization by default

### DIFF
--- a/templates/cephtoolbox.yaml
+++ b/templates/cephtoolbox.yaml
@@ -1,9 +1,0 @@
-apiVersion: ocs.openshift.io/v1
-kind: OCSInitialization
-metadata:
-  name: {{ .Values.toolbox.name }}
-  namespace: {{ .Values.odf.namespace }}
-  annotations:
-    argocd.argoproj.io/sync-wave: "10"
-spec:
-  enableCephTools: {{ .Values.toolbox.enableCephTools }}

--- a/values.yaml
+++ b/values.yaml
@@ -46,10 +46,6 @@ route:
   port:
     targetPort: http
 
-toolbox:
-  name: ocsinit
-  enableCephTools: true
-
 #Define the CephObjectStorage parameters
 objectStorage:
   enable: true


### PR DESCRIPTION
Normally OCSInitialization is created by the operator [1]
Let's drop this by default. A user can still reinstate it by setting
enableCephTools to true.

[1] https://github.com/red-hat-storage/ocs-operator?tab=readme-ov-file#initial-configuration

Closes: #5
