### PR TITLE
Drop region from rgw-storageclass

### DIFF
--- a/templates/rgw-storageclass.yaml
+++ b/templates/rgw-storageclass.yaml
@@ -8,6 +8,5 @@ provisioner: openshift-storage.ceph.rook.io/bucket
 parameters:
   objectStoreName: {{ .Values.odf.storageClass.objectStoreName }}
   objectStoreNamespace: {{ .Values.odf.namespace }}
-  region: {{ .Values.global.datacenter.region }}
 reclaimPolicy: Delete
 volumeBindingMode: Immediate

--- a/values.yaml
+++ b/values.yaml
@@ -1,7 +1,6 @@
 global:
   datacenter:
     storageClassName: gp3-csi
-    region: us-east-1
 
 odf:
   namespace: openshift-storage


### PR DESCRIPTION
According to https://www.github.com/rook/rook/pull/9906
the region spec is not required for configuring the RGW StorageClass.

Let's drop those.

Closes: #4
