### PR TITLE
Switch to host as a default failureDomain for objectStorage

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # openshift-data-foundations
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
 
 A Helm chart to install ODF on Openshift
 
@@ -12,17 +12,22 @@ A Helm chart to install ODF on Openshift
 | ---- | ------ | --- |
 | Validated Patterns Team | <validatedpatterns@googlegroups.com> |  |
 
+## Notes
+
+This branch currently tracks the v0.2.x releases which use the host as a
+default failure domain for objectStorage.
+
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | global.datacenter.storageClassName | string | `"gp3-csi"` |  |
 | job.image | string | `"image-registry.openshift-image-registry.svc:5000/openshift/cli:latest"` |  |
-| objectStorage.dataPool.failureDomain | string | `"zone"` | Failuredomain for the dataPool |
+| objectStorage.dataPool.failureDomain | string | `"host"` | Failuredomain for the dataPool |
 | objectStorage.dataPool.replicas | int | `3` |  |
 | objectStorage.enable | bool | `true` |  |
 | objectStorage.gateway.instances | int | `2` |  |
-| objectStorage.metadataPool.failureDomain | string | `"zone"` | Failuredomain for the metadataPool |
+| objectStorage.metadataPool.failureDomain | string | `"host"` | Failuredomain for the metadataPool |
 | objectStorage.resources.limits.cpu | string | `"2"` |  |
 | objectStorage.resources.limits.memory | string | `"6Gi"` |  |
 | objectStorage.resources.requests.cpu | string | `"1"` |  |

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -9,6 +9,11 @@
 
 {{ template "chart.maintainersSection" . }}
 
+## Notes
+
+This branch currently tracks the v0.2.x releases which use the host as a
+default failure domain for objectStorage.
+
 {{ template "chart.sourcesSection" . }}
 
 {{ template "chart.requirementsSection" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -51,10 +51,10 @@ objectStorage:
   dataPool:
     replicas: 3
     # -- Failuredomain for the dataPool
-    failureDomain: zone
+    failureDomain: host
   metadataPool:
     # -- Failuredomain for the metadataPool
-    failureDomain: zone
+    failureDomain: host
   gateway:
     instances: 2
 


### PR DESCRIPTION
This changes the default so ODF will deploy correctly even when nodes
are on the same AZ (which is the default for RHDP).

We change the minor version because this is a breaking change.
Older v0.1.x versions will be spun off the v0.1.x branch.
